### PR TITLE
feat: Create simple chat form for n8n webhook

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chatbot Test</title>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+</head>
+<body>
+    <div class="container mt-5">
+        <div class="card">
+            <div class="card-header bg-primary text-white">
+                <h4 class="card-title mb-0">Chatbot</h4>
+            </div>
+            <div class="card-body" id="chat-box" style="height: 400px; overflow-y: auto;">
+                <!-- Chat messages will appear here -->
+            </div>
+            <div class="card-footer">
+                <form id="chat-form" class="d-flex">
+                    <input type="text" id="message-input" class="form-control" placeholder="Scrivi un messaggio..." autocomplete="off">
+                    <button type="submit" class="btn btn-primary ms-2">Invia</button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bootstrap JS Bundle -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+    <script>
+        const chatForm = document.getElementById('chat-form');
+        const messageInput = document.getElementById('message-input');
+        const chatBox = document.getElementById('chat-box');
+        const webhookUrl = 'http://localhost:5678/webhook/chat';
+
+        // Funzione per aggiungere un messaggio alla chat-box
+        function addMessage(message, sender) {
+            const messageElement = document.createElement('div');
+            messageElement.classList.add('mb-2');
+
+            const bubble = document.createElement('div');
+            bubble.classList.add('p-2', 'rounded');
+
+            if (sender === 'user') {
+                messageElement.classList.add('text-end');
+                bubble.classList.add('bg-primary', 'text-white', 'd-inline-block');
+            } else {
+                messageElement.classList.add('text-start');
+                bubble.classList.add('bg-light', 'text-dark', 'd-inline-block');
+            }
+
+            bubble.textContent = message;
+            messageElement.appendChild(bubble);
+            chatBox.appendChild(messageElement);
+
+            // Scrolla fino in fondo
+            chatBox.scrollTop = chatBox.scrollHeight;
+        }
+
+        chatForm.addEventListener('submit', async (e) => {
+            e.preventDefault();
+
+            const message = messageInput.value.trim();
+            if (!message) return;
+
+            addMessage(message, 'user');
+            messageInput.value = '';
+
+            try {
+                const response = await fetch(webhookUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ message: message })
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+
+                // Assumendo che n8n risponda con un oggetto JSON che contiene una chiave "reply"
+                const reply = data.reply || "Non ho ricevuto una risposta valida.";
+                addMessage(reply, 'bot');
+
+            } catch (error) {
+                console.error('Errore durante la chiamata al webhook:', error);
+                addMessage('Errore: Impossibile contattare il chatbot.', 'bot');
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a single `index.html` file that implements a simple but elegant chat interface.

The interface is built using Bootstrap for styling and contains all the necessary HTML and JavaScript to:
- Capture user messages from an input form.
- Display messages in a chat window.
- Send user messages to a specified n8n webhook URL.
- Display the chatbot's response.

This provides a complete, self-contained solution for testing a chatbot service via an n8n webhook.