### PR TITLE
feat: Render HTML in bot responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,12 +45,12 @@
             if (sender === 'user') {
                 messageElement.classList.add('text-end');
                 bubble.classList.add('bg-primary', 'text-white', 'd-inline-block');
+                bubble.textContent = message; // Use textContent for user input for security
             } else {
                 messageElement.classList.add('text-start');
                 bubble.classList.add('bg-light', 'text-dark', 'd-inline-block');
+                bubble.innerHTML = message; // Use innerHTML for bot responses to render HTML
             }
-
-            bubble.textContent = message;
             messageElement.appendChild(bubble);
             chatBox.appendChild(messageElement);
 


### PR DESCRIPTION
This commit updates the chat form's JavaScript to render HTML tags in the bot's responses.

The `addMessage` function now uses `innerHTML` to set the content of the bot's message bubble, allowing for rich text formatting like bold, italics, or links.

For security, user-submitted messages continue to use `textContent` to prevent XSS vulnerabilities.